### PR TITLE
keyaki: add NFA_PROPRIETARY_CFG for proper Mifare Classic support

### DIFF
--- a/rootdir/system/etc/libnfc-brcm.conf
+++ b/rootdir/system/etc/libnfc-brcm.conf
@@ -396,7 +396,7 @@ DEFAULT_OFFHOST_ROUTE=0x02
 #  byte[6] NCI_DISCOVERY_TYPE_POLL_KOVIO
 #  byte[7] NCI_DISCOVERY_TYPE_POLL_B_PRIME
 #  byte[8] NCI_DISCOVERY_TYPE_LISTEN_B_PRIME
-NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:70:FF:FF}
+NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:77:FF:FF}
 
 #################################################################################
 # Bail out mode


### PR DESCRIPTION
* NFC stack in Android M has native support for Mifare Classic,
  but default protocol number is wrong. This property will correct
  the number for PN547C2.
* Mostly copied from sample configuration, with
  NCI_DISCOVERY_TYPE_POLL_KOVIO changed to 0x77. Any other value will
  cause errorneous commands sent to NFCC, and NFC stack will fall into
  infinite loop.
* PSE and Android Beam is working.