### PR TITLE
Revert "keyaki: add NFA_PROPRIETARY_CFG for proper Mifare Classic support"

### DIFF
--- a/rootdir/system/etc/libnfc-brcm.conf
+++ b/rootdir/system/etc/libnfc-brcm.conf
@@ -396,7 +396,7 @@ DEFAULT_OFFHOST_ROUTE=0x02
 #  byte[6] NCI_DISCOVERY_TYPE_POLL_KOVIO
 #  byte[7] NCI_DISCOVERY_TYPE_POLL_B_PRIME
 #  byte[8] NCI_DISCOVERY_TYPE_LISTEN_B_PRIME
-NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:77:FF:FF}
+NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:70:FF:FF}
 
 #################################################################################
 # Bail out mode


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-keyaki#5

The config change is working the opposite way on PN553 and actually crashes the NFC chip.