### PR TITLE
Remove unnecessary NFC flags and packages

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -30,7 +30,6 @@ PRODUCT_PLATFORM := tone
 WIFI_BUS := PCIE
 
 # NFC
-NXP_CHIP_TYPE := PN553
 NXP_CHIP_FW_TYPE := PN553
 
 BOARD_KERNEL_CMDLINE += androidboot.hardware=keyaki

--- a/device.mk
+++ b/device.mk
@@ -75,10 +75,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.keyaki
 
-# NFC config
-PRODUCT_PACKAGES += \
-    nfc_nci.keyaki
-
 # Telephony Packages (AOSP)
 PRODUCT_PACKAGES += \
     InCallUI \


### PR DESCRIPTION
* These packages and flags no longer exist
  in AOSP 9 codebase.