### PR TITLE
[KEYAKI] device.mk: Migrate to brcmfmac driver

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -15,6 +15,8 @@
 # Device path
 DEVICE_PATH := device/sony/keyaki/rootdir
 
+WIFI_DRIVER_BUILT := brcmfmac
+
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/keyaki/overlay
 


### PR DESCRIPTION
Add WIFI_DRIVER_BUILT to migrate to brcmfmac.

Goodbye DHD, we won't miss you.

Depends on https://github.com/sonyxperiadev/kernel/pull/1949